### PR TITLE
Hotfix/fix flask caching

### DIFF
--- a/isso/core.py
+++ b/isso/core.py
@@ -19,8 +19,8 @@ if PY2K:
 else:
     import _thread as thread
 
-from flask_caching.backends.null import NullCache
-from flask_caching.backends.simple import SimpleCache
+from flask_caching.backends.nullcache import NullCache
+from flask_caching.backends.simplecache import SimpleCache
 
 logger = logging.getLogger("isso")
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 from setuptools import setup, find_packages
 
 requires = ['itsdangerous', 'Jinja2', 'misaka>=2.0,<3.0', 'html5lib',
-            'werkzeug>=1.0', 'bleach', 'flask-caching']
+            'werkzeug>=1.0', 'bleach', 'flask-caching>=1.9']
 
 if sys.version_info < (3, ):
     raise SystemExit("Python 2 is not supported.")


### PR DESCRIPTION
Fix flask_caching 1.9 backend names
With the new import, we now *require* Flask-Caching 1.9 